### PR TITLE
feat: :sparkles: passar mensagem para validação de erro

### DIFF
--- a/src/components/InputLine/InputLineForm.tsx
+++ b/src/components/InputLine/InputLineForm.tsx
@@ -15,6 +15,7 @@ export interface InputFormProps extends InputProps {
     values: any;
     limit?: number;
     minimum?: number;
+    msgErrorValidate?: string;
 }
 
 const InputLineForm: React.FC<InputFormProps> = ({
@@ -26,6 +27,7 @@ const InputLineForm: React.FC<InputFormProps> = ({
     values,
     limit,
     minimum,
+    msgErrorValidate,
     ...rest
 }) => {
     const [isFieldActive, setIsFieldActive] = useState(false);
@@ -70,14 +72,19 @@ const InputLineForm: React.FC<InputFormProps> = ({
 
         if (limit) {
             if (valueRegister.length > limit) {
-                mensagem = `${limit} caracteres permitidos.`;
+                mensagem =
+                    `${msgErrorValidate}` || `${limit} caracteres permitidos.`;
                 result = false;
             }
         }
 
         if (minimum) {
             if (valueRegister.length < minimum) {
-                mensagem = `${name} deve ter ${minimum} ou mais caracteres.`;
+                mensagem =
+                    `${msgErrorValidate}` ||
+                    `${
+                        rest.label || name
+                    } deve ter ${minimum} ou mais caracteres.`;
                 result = false;
             }
         }


### PR DESCRIPTION
# Descrição
- Foi a adicionado a propriedade que pode enviar a mensagem de erro do validade
- Foi alterado para exibir o label ou name do input na mensagem de erro de caracteres

## Qual a mudança?
Delete as opções que não forem relevantes ou crie outras caso seja necessário

- [x] New feature (adiciona uma feat nova e é non-breaking change )

# Como é que isso pode/deve ser testado?

Teste A -
1. Ao passar uma mensagem de erro validate, ela deverá aparecer ao invés da mensagem padrão de caracteres
2. Caso tenha label no input deverá ser aparecer o nome do label na mensagem de erro de caracteres, caso não aparece o name do input.
- [ ] Test A


# Checklist:

- [x] Meu código segue o guideline (arquitetura/padrões definidos/clean code/solid) definido para este projeto?
- [x] Eu fiz um self review dessa PR?
- [x] Eu comentei o código, principalmente na parte mais complexa de ser entendida?
- [ ] Essa PR gera algum warning?
- [ ] Eu fiz testes automatizados?
- [ ] Os units tests passaram?
